### PR TITLE
fix: ignore error when no gen folders are present 

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "scripts": {
         "generate": "powerhouse generate",
         "reactor": "ph dev",
-        "format-generated": "npx prettier \"**/gen/**/*\" --write --ignore-path /dev/null",
+        "format-generated": "npx prettier \"**/{gen,processors,editors}/**/*\" --write --ignore-path --no-error-on-unmatched-pattern >> /dev/null",
         "postgenerate": "npm run format-generated",
         "check-types": "tsc",
         "postlint": "npm run check-types",


### PR DESCRIPTION
Also format processors and editors